### PR TITLE
Add connection identifier to FFXIVNetworkMonitor callback

### DIFF
--- a/Machina.FFXIV/FFXIVNetworkMonitor.cs
+++ b/Machina.FFXIV/FFXIVNetworkMonitor.cs
@@ -50,25 +50,25 @@ namespace Machina.FFXIV
         { get; set; } = "";
 
         #region Message Delegates section
-        public delegate void MessageReceivedDelegate(long epoch, byte[] message);
+        public delegate void MessageReceivedDelegate(string connection, long epoch, byte[] message);
 
         /// <summary>
         /// Specifies the delegate that is called when data is received and successfully decoded/
         /// </summary>
         public MessageReceivedDelegate MessageReceived = null;
 
-        public void OnMessageReceived(long epoch, byte[] message)
+        public void OnMessageReceived(string connection, long epoch, byte[] message)
         {
-            MessageReceived?.Invoke(epoch, message);
+            MessageReceived?.Invoke(connection, epoch, message);
         }
         
-        public delegate void MessageSentDelegate(long epoch, byte[] message);
+        public delegate void MessageSentDelegate(string connection, long epoch, byte[] message);
 
         public MessageSentDelegate MessageSent = null;
 
-        public void OnMessageSent(long epoch, byte[] message)
+        public void OnMessageSent(string connection, long epoch, byte[] message)
         {
-            MessageSent?.Invoke(epoch, message);
+            MessageSent?.Invoke(connection, epoch, message);
         }
 
         #endregion
@@ -125,7 +125,7 @@ namespace Machina.FFXIV
             _sentDecoders[connection].StoreData(data);
             while ((message = _sentDecoders[connection].GetNextFFXIVMessage()) != null)
             {
-                OnMessageSent(message.Item1, message.Item2);
+                OnMessageSent(connection, message.Item1, message.Item2);
             }
         }
 
@@ -138,7 +138,7 @@ namespace Machina.FFXIV
             _receivedDecoders[connection].StoreData(data);
             while ((message = _receivedDecoders[connection].GetNextFFXIVMessage()) != null)
             {
-                OnMessageReceived(message.Item1, message.Item2);
+                OnMessageReceived(connection, message.Item1, message.Item2);
             }
 
         }

--- a/Machina.FFXIV/Machina.FFXIV.csproj
+++ b/Machina.FFXIV/Machina.FFXIV.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>if $(ConfigurationName) == Release (
+    <PostBuildEvent>if "$(SolutionName)" == "Machina" if $(ConfigurationName) == Release (
 $(SolutionDir).nuget\nuget.exe pack $(ProjectPath) -Properties Configuration=$(ConfigurationName) -Properties Platform=$(PlatformName) -IncludeReferencedProjects -Symbols -OutputDirectory ..\packages\
 %25SYSTEMROOT%25\System32\WindowsPowerShell\v1.0\powershell.exe –NonInteractive –ExecutionPolicy Unrestricted –command "&amp; { &amp;'$(SolutionDir)RenameSymbolsToPackage.ps1' '$(TargetName)' }"
 )</PostBuildEvent>

--- a/Machina/Machina.csproj
+++ b/Machina/Machina.csproj
@@ -75,7 +75,7 @@
     </PropertyGroup>
   </Target>
   <PropertyGroup>
-    <PostBuildEvent>if $(ConfigurationName) == Release (
+    <PostBuildEvent>if "$(SolutionName)" == "Machina" if $(ConfigurationName) == Release (
 $(SolutionDir).nuget\nuget.exe pack $(ProjectPath) -Properties Configuration=$(ConfigurationName) -Properties Platform=$(PlatformName) -IncludeReferencedProjects -Symbols -OutputDirectory ..\packages\
 %25SYSTEMROOT%25\System32\WindowsPowerShell\v1.0\powershell.exe –NonInteractive –ExecutionPolicy Unrestricted –command "&amp; { &amp;'$(SolutionDir)RenameSymbolsToPackage.ps1' '$(TargetName)' }"
 )</PostBuildEvent>


### PR DESCRIPTION
FFXIV has two connections and both of them have their own ping & heart beat. Need to distinguish them to calculate the correct lag.