### PR TITLE
Add window class support for window searching

### DIFF
--- a/Machina/ProcessTCPInfo.cs
+++ b/Machina/ProcessTCPInfo.cs
@@ -130,7 +130,7 @@ namespace Machina
         {
             if (ProcessID > 0)
                 _currentProcessID = ProcessID;
-            else if(string.IsNullOrWhiteSpace(ProcessWindowClass)) // i prefer it first since it's language irrelevant, ascii only and constant until the window being destroyed.
+            else if(!string.IsNullOrWhiteSpace(ProcessWindowClass)) // i prefer it first since it's language irrelevant, ascii only and constant until the window being destroyed.
                 _currentProcessID = GetProcessIDByWindowClass(ProcessWindowClass);
             else
                 _currentProcessID = GetProcessIDByWindowName(ProcessWindowName);         

--- a/Machina/ProcessTCPInfo.cs
+++ b/Machina/ProcessTCPInfo.cs
@@ -115,7 +115,7 @@ namespace Machina
         public uint GetProcessIDByWindowClass(string windowClass)
         {
             uint processID;
-            IntPtr hWindow = FindWindowEx(null, null, windowClass, null);
+            IntPtr hWindow = FindWindowEx(IntPtr.Zero, IntPtr.Zero, windowClass, null);
             GetWindowThreadProcessId(hWindow, out processID);
 
             return processID;

--- a/Machina/TCPNetworkMonitor.cs
+++ b/Machina/TCPNetworkMonitor.cs
@@ -14,6 +14,7 @@ namespace Machina
     ///   MonitorType: Specifies whether it should use a winsock raw socket, or use WinPCap (requires separate kernel driver installation).  Default is a raw socket.
     ///   ProcessID: Specifies the process ID to record traffic from
     ///   WindowName: Specifies the window name to record traffic from, where process ID is unavailable
+    ///   WindowClass: Specifies the window class to record traffic from, where process ID is unavailable
     ///   DataReceived: Delegate that is called when data is received and successfully decoded through IP and TCP decoders.  Note that a connection identifier is 
     ///     supplied to distinguish between multiple connections from the same process.
     ///   DataSent: Delegate that is called when data is sent and successfully decoded through IP and TCP decoders.  Note that a connection identifier is 
@@ -42,7 +43,7 @@ namespace Machina
         { get; set; } = NetworkMonitorType.RawSocket;
 
         /// <summary>
-        /// Specifies the Process ID that is generating or receiving the traffic.  Either ProcessID or WindowName must be specified.
+        /// Specifies the Process ID that is generating or receiving the traffic.  Either ProcessID, WindowName or WindowClass must be specified.
         /// </summary>
         public uint ProcessID
         { get; set; } = 0;
@@ -54,9 +55,15 @@ namespace Machina
         { get; set; } = "";
         
         /// <summary>
-        /// Specifies the Window Name of the application that is generating or receiving the traffic.  Either ProcessID or WindowName must be specified.
+        /// Specifies the Window Name of the application that is generating or receiving the traffic.  Either ProcessID, WindowName or WindowClass must be specified.
         /// </summary>
         public string WindowName
+        { get; set; } = "";
+        
+        /// <summary>
+        /// Specifies the Window Class of the application that is generating or receiving the traffic.  Either ProcessID, WindowName or WindowClass must be specified.
+        /// </summary>
+        public string WindowClass
         { get; set; } = "";
 
         public bool UseSocketFilter
@@ -114,13 +121,14 @@ namespace Machina
         /// </summary>
         public void Start()
         {
-            if (ProcessID == 0 && string.IsNullOrWhiteSpace(WindowName))
-                throw new ArgumentException("Either Process ID or Window Name must be specified");
+            if (ProcessID == 0 && string.IsNullOrWhiteSpace(WindowName) && string.IsNullOrWhiteSpace(WindowClass))
+                throw new ArgumentException("Either Process ID, Window Name or Window Class must be specified");
             if (DataReceived == null)
                 throw new ArgumentException("DataReceived delegate must be specified.");
 
             _processTCPInfo.ProcessID = ProcessID;
             _processTCPInfo.ProcessWindowName = WindowName;
+            _processTCPInfo.ProcessWindowClass = WindowClass;
 
             _monitorThread = new Thread(new ParameterizedThreadStart(Run));
             _monitorThread.Name = "Machina.TCPNetworkMonitor.Start";


### PR DESCRIPTION
This PR adds support to search window by window class.

As you may know, either FFXIV or other programs may have different window titles among different versions, languages or options. Some even change their title on-the-fly. (e.g. `Final Fantasy XIV` for FFXIV EN version and `最终幻想XIV` for FFXIV CN version. Some apps like Telegram change their window title when new message comes.)

As an alternative option, I added window class support for Machina. Which is language irrelevant, ascii only (common practice) and constant until the window destroyed. In addition, window class is generally not likely changed by program developers, so it's more suitable as unique identifiers for use in search.

P.S. Class name of FFXIV is `FFXIVGAME`. You can easily get the class name of any window by using Spy++ (spyxx.exe or spyxx_amd64.exe) installed with Visual Studio.
P.S.2 Tested it out on a third-party modified version of FFXIV_ACT_PLUGIN, works fine. (NGA version, for CN server 4.4, based on 1.7.0.11) 