### PR TITLE
Fix issue when txt file line separator is \n when cloned by git

### DIFF
--- a/Machina.FFXIV/Headers/Opcodes/OpcodeManager.cs
+++ b/Machina.FFXIV/Headers/Opcodes/OpcodeManager.cs
@@ -39,7 +39,7 @@ namespace Machina.FFXIV.Headers.Opcodes
                     using (StreamReader sr = new StreamReader(stream))
                     {
                         string[][] data = sr.ReadToEnd()
-                            .Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries)
+                            .Split(new string[] { "\r", "\n" }, StringSplitOptions.RemoveEmptyEntries)
                             .Select(x => x.Split(new string[] { "|" }, StringSplitOptions.RemoveEmptyEntries)).ToArray();
 
                         var dict = data.ToDictionary(


### PR DESCRIPTION
Some git client will modify the line separator to "\n" (such the one used by AppVeyor CI) which causes the `TypeInitializationException`:
https://github.com/Noisyfox/ACT.FFXIVPing/issues/7