### PR TITLE
Allow packet capture from Wireguard VPN tunnels

### DIFF
--- a/Machina/Sockets/PCapCaptureSocket.cs
+++ b/Machina/Sockets/PCapCaptureSocket.cs
@@ -130,8 +130,8 @@ namespace Machina.Sockets
 
                 // check data link type
                 _activeDevice.LinkType = pcap_datalink(_activeDevice.Handle);
-                if (_activeDevice.LinkType != DLT_EN10MB && _activeDevice.LinkType != DLT_NULL)
-                    throw new PcapException($"PCapCaptureSocket: Interface [{device.Description}] does not appear to support Ethernet.");
+                if (_activeDevice.LinkType != DLT_EN10MB && _activeDevice.LinkType != DLT_RAW && _activeDevice.LinkType != DLT_NULL)
+                    throw new PcapException($"PCapCaptureSocket: Interface [{device.Description}] does not appear to support Ethernet or raw IP.");
 
                 // create filter
                 if (pcap_compile(_activeDevice.Handle, ref filter, filterText, 1, 0) != 0)
@@ -207,7 +207,7 @@ namespace Machina.Sockets
                     IntPtr packetDataPtr = IntPtr.Zero;
                     IntPtr packetHeaderPtr = IntPtr.Zero;
 
-                    int layer2Length = _activeDevice.LinkType == DLT_EN10MB ? 14 : 4; // 14 for ethernet, 4 for loopback
+                    int layer2Length = _activeDevice.LinkType == DLT_EN10MB ? 14 : _activeDevice.LinkType == DLT_RAW ? 0 : 4; // 14 for ethernet, 0 for raw IP, 4 for loopback
 
                     // note: buffer returned by pcap_next_ex is static and owned by pcap library, does not need to be freed.
                     int status = pcap_next_ex(_activeDevice.Handle, ref packetHeaderPtr, ref packetDataPtr);

--- a/Machina/Sockets/PcapInterop.cs
+++ b/Machina/Sockets/PcapInterop.cs
@@ -88,6 +88,7 @@ namespace Machina.Sockets
 
         // supported Data Link types, from bpf.h
         internal const int DLT_EN10MB = 1; // 14-byte header (may also be a 4 byte 802.1Q vlan header!)
+        internal const int DLT_RAW = 12; // no header
         internal const int DLT_NULL = 0; // 4-byte header
 
         internal const int AF_INET = 2; // Address Family IPv4


### PR DESCRIPTION
This PR adds support for capturing packets from Wireguard VPN tunnels, and potentially other similar interfaces which use the raw IP Data Link type. This is simply a matter of defining DLT_RAW as per bpf.h and a couple of other small changes to account for the new type and its lack of a header.

I've tested locally by fudging FFXIV_ACT_Plugin with ILSpy so it would load my custom machina build and everything seems to work as intended - I didn't see any regressions when capturing from a normal Ethernet interface either.