### PR TITLE
Fix infinite loop and correct header found logic

### DIFF
--- a/Machina.FFXIV/FFXIVBundleDecoder.cs
+++ b/Machina.FFXIV/FFXIVBundleDecoder.cs
@@ -186,27 +186,28 @@ namespace Machina.FFXIV
             return _decompressionBuffer;
         }
 
-        private unsafe int ResetStream(int offset)
+        private unsafe int ResetStream(int currentOffset)
         {
-            offset = GetNextMagicNumberPos(_bundleBuffer, offset);
-            if (offset == -1)
+            int nextOffset = GetNextMagicNumberPos(_bundleBuffer, currentOffset);
+            if (nextOffset == -1)
             {
                 //reset stream
                 _allocated = 0;
                 _bundleBuffer = null;
             }
 
-            return offset;
+            return nextOffset;
         }
 
-        private static unsafe int GetNextMagicNumberPos(byte[] buffer, int offset)
+        private static unsafe int GetNextMagicNumberPos(byte[] buffer, int currentOffset)
         {
             fixed (byte* ptr = buffer)
             {
-                for (int i = 0; i < (buffer.Length - offset) / 4; i++)
+                for (int nextOffset = currentOffset + 1; nextOffset < buffer.Length - 4; nextOffset++)
                 {
-                    if (((int*)(ptr + offset + i))[0] == 0x5252a041)
-                        return i;
+                    if (((int*)(ptr + nextOffset))[0] == 0x5252a041) {
+                        return nextOffset;
+                    }
                 }
             }
 


### PR DESCRIPTION
When hitting bad data it will go into infinite loop and the logic there is incorrect for finding header (it should finding every data not the data in data.length/4), also it should return the value of i+offset and start find it from offset+1.
Thanks to @Noisyfox and others for helping me in this issue!