### PR TITLE
Allow FFXIV window title to be set as a parameter

### DIFF
--- a/Machina.FFXIV/FFXIVNetworkMonitor.cs
+++ b/Machina.FFXIV/FFXIVNetworkMonitor.cs
@@ -61,6 +61,12 @@ namespace Machina.FFXIV
         { get; set; }
 
         /// <summary>
+        /// The window name to use for game detection.
+        /// </summary>
+        public string WindowName
+        { get; set; } = "FINAL FANTASY XIV";
+
+        /// <summary>
         /// This class keeps the information needed to authenticate the user on a remote machine or read a local file via PCap.
         /// The remote machine can either grant or refuse the access according to the information provided. In case the NULL authentication is required, both 'username' and 'password' can be NULL pointers.
         /// </summary>
@@ -118,7 +124,7 @@ namespace Machina.FFXIV
             _monitor.Config.ProcessID = ProcessID;
             _monitor.Config.ProcessIDList = ProcessIDList;
             if (_monitor.Config.ProcessID == 0)
-                _monitor.Config.WindowName = "FINAL FANTASY XIV";
+                _monitor.Config.WindowName = WindowName;
             _monitor.Config.MonitorType = MonitorType;
             _monitor.Config.LocalIP = LocalIP;
             _monitor.Config.UseRemoteIpFilter = UseRemoteIpFilter;


### PR DESCRIPTION
The Chinese version of the game uses the window title 最终幻想XIV; adding the window title as a parameter allows us to set that as needed.