### PR TITLE
Prevent re-injection for deucalion

### DIFF
--- a/Machina.FFXIV/Deucalion/DeucalionInjector.cs
+++ b/Machina.FFXIV/Deucalion/DeucalionInjector.cs
@@ -187,6 +187,19 @@ namespace Machina.FFXIV.Deucalion
 
             // Note: if this method does not work, do not stop processing.  If user runs with elevated permissions, injection will still work.
             _ = UpdateProcessDACL(processId);
+            
+            // Ensure the dll not be re-injected. (It will prevent auto unload since its ref always beyond 0 if that happened)
+            using (Process process = Process.GetProcessById(processId))
+            {
+                foreach (ProcessModule module in process.Modules)
+                {
+                    if (module.ModuleName == _resourceFileName)
+                    {
+                        Trace.WriteLine($"DeucalionInjector: Deucalion has already inject into process {processId}.", "DEBUG-MACHINA");
+                        return true;
+                    }
+                }
+            }
 
             IntPtr procHandle = IntPtr.Zero;
             IntPtr threadHandle = IntPtr.Zero;


### PR DESCRIPTION
It will prevent dll auto unload if that happens (Since its ref always beyond zero), and will cause no data issue when using FFXIV_ACT_Plugin for multiple process switching.

Ref: 
https://github.com/ravahn/machina/blob/e2c8c11924c33e28bd3f8ebab6bff374f0aaba7d/Machina.FFXIV/Deucalion/DeucalionInjector.cs#L206
https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryw
https://github.com/ff14wed/deucalion/blob/a6f3239dc371ad27ce1e8006c0ef65ce7373c596/src/lib.rs#LL223C26-L223C26
https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-freelibraryandexitthread

